### PR TITLE
Fix Peach Ice Cream test failing

### DIFF
--- a/lessons/L5/problem-set/07-making-peach-ice-cream/tests.json
+++ b/lessons/L5/problem-set/07-making-peach-ice-cream/tests.json
@@ -55,7 +55,10 @@
       "definition": {
         "nodes": ".recipe-note",
         "cssProperty": "display",
-        "equals": "inline"
+        "equals": [
+          "inline",
+          "inline-block"
+        ]
       }
     }
   ]


### PR DESCRIPTION
* lessons/L5/problem-set/07-making-peach-ice-cream/tests.json (three
  recipe notes test): Add `inline-block` as a valid test case.